### PR TITLE
Simplify `lex_expression` and update `__all__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Micro Liquid Change Log
+
+## Version 0.1.1 (unreleased)
+
+- Changed `Scanner.lex_expression` to handle quotes as part of the punctuation pattern rather than treating them as a special case.
+- Added `TemplateError` and `UndefinedVariableError` to `__all__`.
+
+## Version 0.1.0
+
+Initial release.


### PR DESCRIPTION
This PR changes `Scanner.lex_expression` to handle quotes as part of the punctuation pattern rather than treating them as a special case.

We also add `TemplateError` and `UndefinedVariableError` to `__all__` in case someone wants to do `from micro_liquid import *`.